### PR TITLE
Fix: Fixed '--no-sandbox', to use this plugin in an ubuntu envirorment

### DIFF
--- a/src/models/HTMLToPDF.ts
+++ b/src/models/HTMLToPDF.ts
@@ -8,7 +8,7 @@ export default class HTMLToPDF {
 
   private _options: HTMLToPDFOptions = {
     browserOptions: {
-      args: ['--font-render-hinting=none'],
+      args: ['--font-render-hinting=none', '--no-sandbox'],
     },
     pdfOptions: {
       printBackground: true,


### PR DESCRIPTION
In order to use this plugin in a Ubuntu environment, puppetter needs to have the '--no-sandbox' option, not sure if this breaks the usage in other environments 